### PR TITLE
fix:  foot 始终贴于页面底部

### DIFF
--- a/source/css/normal.styl
+++ b/source/css/normal.styl
@@ -15,6 +15,10 @@ html {
 html, body {
   margin: 0;
   padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 a {


### PR DESCRIPTION
当文章内容过短时，页面 `foot` 部分不在页面底部，而使出现空白。修改了 body 的样式，使之变为弹性布局：`justify-content: space-between `。