### PR TITLE
fix gitalk Validation Failed

### DIFF
--- a/layout/_third_party/gitalk.njk
+++ b/layout/_third_party/gitalk.njk
@@ -1,7 +1,8 @@
 <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
 <script type="text/javascript">
   const param = JSON.parse('{{ theme.gitalk | dump }}')
-  param.id = location.pathname
+  let title = location.pathname.substr(0, 50); 
+  param.id = title
   const gitalk = new Gitalk(param)
   gitalk.render('gitalk-container')
 </script>


### PR DESCRIPTION
解决开启gitalk后，因为github限制lable长度导致如下报错
Error: Validation Failed